### PR TITLE
docs: update stackbit cli docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Documentation
 
-To learn more about Stackbit CLI please visit [documentation](https://www.stackbit.com/docs/stackbit-cli/)
+To learn more about Stackbit CLI please visit
+[documentation](https://docs.stackbit.com/how-to-guides/site-management/integrate-stackbit/#install_stackbit_cli)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Documentation
 
 To learn more about Stackbit CLI please visit
-[documentation](https://docs.stackbit.com/how-to-guides/site-management/integrate-stackbit/#install_stackbit_cli)
+[documentation](https://docs.stackbit.com/reference/stackbit-cli/)
 
 ## Install
 


### PR DESCRIPTION
Update documentation link so that user would get [this](https://docs.stackbit.com/how-to-guides/site-management/integrate-stackbit/#install_stackbit_cli):

<img width="1345" alt="Screen Shot 2022-06-21 at 3 11 06" src="https://user-images.githubusercontent.com/720339/174691332-06b0c03e-433a-4140-a3cc-a6101e2dd768.png">


rather than [this](https://docs.stackbit.com/stackbit-cli/):

<img width="1614" alt="Screen Shot 2022-06-21 at 3 10 17" src="https://user-images.githubusercontent.com/720339/174691296-a55d16ae-a8ca-4d3c-998a-140b3ac00be5.png">
